### PR TITLE
Use nightly version in app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,7 @@ jobs:
         run: |
           sudo apt update && sudo apt install flatpak flatpak-builder elfutils
       - name: Increase patch version
+        shell: bash
         run: |
           npm version patch
           echo "PKG_VERSION=$(npm pkg get version --workspaces=false | tr -d \")-nightly.${{ steps.current-time.outputs.formattedTime }}" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
         uses: josStorer/get-current-time@v2.0.1
         id: current-time
         with:
-          format: YYYY.MM.DD
+          format: YYYY-MM-DD
       - name: Checkout main
         uses: actions/checkout@v2
         with:
@@ -70,6 +70,11 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
           sudo apt update && sudo apt install flatpak flatpak-builder elfutils
+      - name: Increase patch version
+        run: |
+          npm version patch
+          echo "PKG_VERSION=$(npm pkg get version --workspaces=false | tr -d \")-nightly.${{ steps.current-time.outputs.formattedTime }}" >> $GITHUB_ENV
+          npm version ${{ env.PKG_VERSION }}
       - name: Build nightly release
         run: cd ./chaiNNer && npm run make
       - name: Set file name env vars
@@ -84,19 +89,19 @@ jobs:
           echo "NUPKG=$(find ./chaiNNer/out/make/ -iname *.nupkg)" >> $GITHUB_ENV
       - name: Rename zip assets
         if: ${{ env.ZIP }}
-        run: mv ${{ env.ZIP }} ./chaiNNer/out/make/chaiNNer-${{ matrix.os }}-nightly-${{ steps.current-time.outputs.formattedTime }}.zip
+        run: mv ${{ env.ZIP }} ./chaiNNer/out/make/chaiNNer-${{ matrix.os }}-nightly.${{ steps.current-time.outputs.formattedTime }}.zip
       - name: Rename dmg assets
         if: ${{ env.DMG }}
-        run: mv ${{ env.DMG }} ./chaiNNer/out/make/chaiNNer-${{ matrix.os }}-nightly-${{ steps.current-time.outputs.formattedTime }}.dmg
+        run: mv ${{ env.DMG }} ./chaiNNer/out/make/chaiNNer-${{ matrix.os }}-nightly.${{ steps.current-time.outputs.formattedTime }}.dmg
       - name: Rename deb assets
         if: ${{ env.DEB }}
-        run: mv ${{ env.DEB }} ./chaiNNer/out/make/chaiNNer-${{ matrix.os }}-nightly-${{ steps.current-time.outputs.formattedTime }}.deb
+        run: mv ${{ env.DEB }} ./chaiNNer/out/make/chaiNNer-${{ matrix.os }}-nightly.${{ steps.current-time.outputs.formattedTime }}.deb
       - name: Rename rpm assets
         if: ${{ env.RPM }}
-        run: mv ${{ env.RPM }} ./chaiNNer/out/make/chaiNNer-${{ matrix.os }}-nightly-${{ steps.current-time.outputs.formattedTime }}.rpm
+        run: mv ${{ env.RPM }} ./chaiNNer/out/make/chaiNNer-${{ matrix.os }}-nightly.${{ steps.current-time.outputs.formattedTime }}.rpm
       - name: Rename exe assets
         if: ${{ env.EXE }}
-        run: mv "${{ env.EXE }}" "./chaiNNer/out/make/chaiNNer-${{ matrix.os }}-nightly-${{ steps.current-time.outputs.formattedTime }}.exe"
+        run: mv "${{ env.EXE }}" "./chaiNNer/out/make/chaiNNer-${{ matrix.os }}-nightly.${{ steps.current-time.outputs.formattedTime }}.exe"
       - name: Delete nupkg assets
         if: ${{ env.NUPKG }}
         run: rm ${{ env.NUPKG }}


### PR DESCRIPTION
This abuses some npm commands to:
1. up the version by a patch in order to signify its later than the existing version
2. append `-nightly.YYYY-MM-DD` to the version

This means that in the nightly builds, it will no longer seem like its just the previous version of the app. it'll be clear that you are using a nightly.