### PR TITLE
Fixed nightly version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,8 +75,8 @@ jobs:
         run: |
           cd ./chaiNNer
           npm version patch --no-git-tag-version
-          echo "PKG_VERSION=$(npm pkg get version --workspaces=false | tr -d \")-nightly.${{ steps.current-time.outputs.formattedTime }}" >> $GITHUB_ENV
-          npm version ${{ env.PKG_VERSION }} --no-git-tag-version
+          PKG_VERSION=$(npm pkg get version --workspaces=false | tr -d \")-nightly.${{ steps.current-time.outputs.formattedTime }}
+          npm version $PKG_VERSION --no-git-tag-version
       - name: Build nightly release
         run: cd ./chaiNNer && npm run make
       - name: Set file name env vars


### PR DESCRIPTION
The issue was that GitHubn does `${{ ... }}` substitutions *before* running the whole command. So setting `PKG_VERSION` inside the command meant that it was still unset/empty when the substitution happened. We can see this in the logs of the last nightly release.

![image](https://github.com/chaiNNer-org/chaiNNer-nightly/assets/20878432/c6fa5fce-3dee-4d4a-9a73-fbb9e15f2c65)

Notice that no version is substituted in.

To fix this, I used good old bash variables. Pasting the whole command into bash works perfectly on my machine. (I had to remove the date substitution, of course.)